### PR TITLE
Add fap_category=NFC to application.fam so it gets put in the NFC folder when built and …

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -10,4 +10,5 @@ App(
     stack_size=4 * 1024,
     order=30,
     fap_icon_assets="assets",
+    fap_category="NFC",
 )


### PR DESCRIPTION
Add fap_category=NFC to application.fam so it gets put in the NFC folder when built and launched via ufbt, instead of the root of the apps folder.